### PR TITLE
associate snippets with users

### DIFF
--- a/pastebin_project/snippets/serializers.py
+++ b/pastebin_project/snippets/serializers.py
@@ -3,9 +3,10 @@ from .models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 from django.contrib.auth.models import User
 
 class SnippetSerializer(serializers.ModelSerializer):
+    owner = serializers.ReadOnlyField(source='owner.username')
     class Meta:
         model = Snippet
-        fields = ['id', 'title', 'code', 'linenos', 'language', 'style']
+        fields = ['id', 'title', 'code', 'linenos', 'language', 'style', 'owner']
     # id = serializers.IntegerField(read_only=True)
     # title = serializers.CharField(required=False, allow_blank=True, max_length=100)
     # code = serializers.CharField(style={'base_template': 'textarea.html'})

--- a/pastebin_project/snippets/urls.py
+++ b/pastebin_project/snippets/urls.py
@@ -5,7 +5,7 @@ from snippets import views
 urlpatterns = [
     path('snippets/', views.SnippetList.as_view()),
     path('users/', views.UserList.as_view()),
-    path('snippets/<int:pk>', views.SnippetDetail.as_view())
+    path('snippets/<int:pk>', views.SnippetDetail.as_view()),
     path('users/<int:pk>', views.UserDetail.as_view())
 ]
 

--- a/pastebin_project/snippets/views.py
+++ b/pastebin_project/snippets/views.py
@@ -6,12 +6,13 @@
 # from rest_framework.decorators import api_view
 # from rest_framework.views import APIView
 # from rest_framework.response import Response
-from rest_framework import generics
+from rest_framework import generics, permissions
 # from rest_framework import mixins, generics
 # from django.http import Http404
 from snippets.models import Snippet
 from snippets.serializers import SnippetSerializer, UserSerializer
 from django.contrib.auth.models import User
+
 
 # Create your views here.
 
@@ -19,11 +20,12 @@ from django.contrib.auth.models import User
 class SnippetList(generics.ListCreateAPIView):
    queryset = Snippet.objects.all()
    serializer_class = SnippetSerializer
-
+   permission_classes = [permissions.IsAuthenticatedOrReadOnly]
    """
    List all code snippets, or create a new snippet.
    """
-   
+   def perform_create(self, serializer):
+      serializer.save(owner=self.request.user)
    # def get(self, request, *args, **kwargs):
    #    return self.list(request, *args, **kwargs)
 
@@ -65,7 +67,7 @@ class SnippetDetail(generics.RetrieveUpdateDestroyAPIView):
 
     queryset = Snippet.objects.all()
     serializer_class = SnippetSerializer
-
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
    #  def get(self, request, *args, **kwargs):
    #   return self.retrieve(request, *args, **kwargs)
 


### PR DESCRIPTION
#### What does this PR do?

- associate snippets with users

#### Description of Task to be completed?

- override the perform_create method on the snippet views
- update the snippetserializer to reflect the user model association by adding a read-only owner field to the class
- add isauthenticatedorreadonly permission class to the snippetdetails and snippetlist views


#### How should this be manually tested?

- N/A

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- N/A

#### Screenshots (if appropriate)

- N/A

#### Questions:

- N/A
